### PR TITLE
KAT-5506: Add more Ad-tag repos to Release Notes Generator

### DIFF
--- a/main.js
+++ b/main.js
@@ -130,9 +130,9 @@ const projectList = {
         longName: 'Ad Platform Templates',
         jiraShortName: 'KAT'
     },
-    KALITRA: {
-        githubName: 'ad-kalitra',
-        longName: 'Kalitra',
+    KAILTRA: {
+        githubName: 'ad-kailtra',
+        longName: 'Kailtra',
         jiraShortName: 'KAT'
     },
 };


### PR DESCRIPTION
## 🏹 - Proposed Changes
* Kailtra release notes generator blocked by misspelling.

## 🎯 - Checklist
* [x] Tested locally
* [x] Added milestone, labels, reviewers

## 📌 - Related Jira Ticket
* [KAT-5506](https://kargo1.atlassian.net/browse/KAT-5506)